### PR TITLE
Change to slightly awkward wording

### DIFF
--- a/doc_source/serverless-app-consuming-applications.md
+++ b/doc_source/serverless-app-consuming-applications.md
@@ -12,7 +12,7 @@ Find, configure, and deploy an application in the AWS Serverless Application Rep
 
 1. Browse or search for an application\.
 
-1. Choose an application to view more details about it, such as its capabilities and the number of times it has been deployed by AWS customers\. \(Note: The deployment counts are shown for the region in which you are trying to deployment application\)
+1. Choose an application to view details such as its capabilities and the number of times it has been deployed by AWS customers\. \(Note: The deployment counts are shown for the region in which you are trying to deployment application\)
 
 1. On the application detail page, you can view the application's permissions, application resources via the SAM template, license, and readme file\. You can also find the **Source code URL** link for applications that are publicly shared\.
 


### PR DESCRIPTION
In the existing text, the use of the phrase 'view more details about it' doesn't make sense in context, as what (if any) details would be visible before choosing an application are not stated. This change makes this sentence more clear in context and saves a few words in the process.

Furthermore, this wording does not require the comma.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
